### PR TITLE
Fix libtool error

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+rm aclocal.m4
+
+aclocal
+autoconf
+
 ./bootstrap.sh
 
 if [[ `uname` == 'Darwin' ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 8c0516e3252ff39a245e62f1a59d0165
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:
@@ -21,7 +21,7 @@ requirements:
     - autoconf
     - automake
     - cunit
-    - ncurses
+    - ncurses 5.9*
   run:
     - fftw
     - libgcc


### PR DESCRIPTION
Turns out we need to regenerate `aclocal.m4` as the one included is generated with an older version of `libtool`. So, we fix this problem here by regenerating `aclocal.m4`. Also, merges PR ( https://github.com/conda-forge/nfft-feedstock/pull/3 ) to pin versions correctly (though we can discuss if that should be kept).

cc @pelson @grlee77
