### PR TITLE
build version to 3.2.4 as needed for pynfft

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.4.1" %}
+{% set version = "3.2.4" %}
 
 package:
   name: nfft
@@ -6,11 +6,11 @@ package:
 
 source:
   fn: nfft-{{ version }}.tar.gz
-  url: https://github.com/NFFT/nfft/releases/download/{{ version }}/nfft-{{ version }}.tar.gz
-  md5: 9c2ad6cf86fe4a7bc0de8d2d92b101f4
+  url: https://www-user.tu-chemnitz.de/~potts/nfft/download/nfft-{{ version }}.tar.gz
+  sha256: 31932438bd28609bcc32bef23830994fe6ac26d411d2077cde782faa5d21207e
 
 build:
-  number: 1001
+  number: 1000
   skip: True  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   fn: nfft-{{ version }}.tar.gz
   url: https://www-user.tu-chemnitz.de/~potts/nfft/download/nfft-{{ version }}.tar.gz
-  sha256: 31932438bd28609bcc32bef23830994fe6ac26d411d2077cde782faa5d21207e
+  sha256: 1405a9eb7eb3c74866afe63026d411f6b4ed2eef5f353783adc7a86933d9f263
 
 build:
   number: 1000


### PR DESCRIPTION
The last release of pyNFFT needs version 3.2.x of this library. This PR rebuild 3.2.4 using the new compilers.

Only releases 3.3+ are on GitHub, so I had to switch the download location.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
