### PR TITLE
Build library for single, double and extended precison

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -27,3 +27,31 @@ fi
 make
 make check
 make install
+
+make clean
+./configure --prefix=$PREFIX \
+            --enable-applications \
+            --enable-all \
+            --enable-openmp \
+            --enable-single \
+            --with-fftw3-libdir=$PREFIX/lib \
+            --with-fftw3-includedir=$PREFIX/include \
+            --with-window=kaiserbessel
+
+make
+make check
+make install
+
+make clean
+./configure --prefix=$PREFIX \
+            --enable-applications \
+            --enable-all \
+            --enable-openmp \
+            --enable-long-double \
+            --with-fftw3-libdir=$PREFIX/lib \
+            --with-fftw3-includedir=$PREFIX/include \
+            --with-window=kaiserbessel
+
+make
+make check
+make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5f78a9d2a675aee7ace55c96bdf1b54f049e05a1dd50697757bdc609a8586a07
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,11 +39,23 @@ requirements:
 test:
   commands:
     - test -f ${PREFIX}/lib/libnfft3.a
+    - test -f ${PREFIX}/lib/libnfft3f.a
+    - test -f ${PREFIX}/lib/libnfft3l.a
     - test -f ${PREFIX}/lib/libnfft3.so  # [linux]
+    - test -f ${PREFIX}/lib/libnfft3f.so  # [linux]
+    - test -f ${PREFIX}/lib/libnfft3l.so  # [linux]
     - test -f ${PREFIX}/lib/libnfft3.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libnfft3f.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libnfft3l.dylib  # [osx]
     - test -f ${PREFIX}/lib/libnfft3_threads.a
+    - test -f ${PREFIX}/lib/libnfft3f_threads.a
+    - test -f ${PREFIX}/lib/libnfft3l_threads.a
     - test -f ${PREFIX}/lib/libnfft3_threads.so  # [linux]
+    - test -f ${PREFIX}/lib/libnfft3f_threads.so  # [linux]
+    - test -f ${PREFIX}/lib/libnfft3l_threads.so  # [linux]
     - test -f ${PREFIX}/lib/libnfft3_threads.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libnfft3f_threads.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libnfft3l_threads.dylib  # [osx]
 
 about:
   home: http://www.nfft.org/


### PR DESCRIPTION
This will be needed for https://github.com/pyNFFT/pyNFFT/pull/63

---

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] ~Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
